### PR TITLE
test: implement test CRDs() function specific to this stack-gcp repo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,7 +57,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:583e0fa981344e825692590e0a7e52d98dc826a17bcc48537be7c0e95593b46d"
+  digest = "1:d88c52c89616a7efaa4dcf75f23ab20c7966f07a51e5ef83a049aefb058a731d"
   name = "github.com/crossplaneio/crossplane"
   packages = [
     "apis",
@@ -75,7 +75,6 @@
     "apis/storage/v1alpha1",
     "apis/workload",
     "apis/workload/v1alpha1",
-    "pkg/test",
   ]
   pruneopts = "UT"
   revision = "3cdf7144bfbe3f370b0de0b96330c67c589c6e82"
@@ -1248,7 +1247,6 @@
     "github.com/crossplaneio/crossplane/apis/compute/v1alpha1",
     "github.com/crossplaneio/crossplane/apis/database/v1alpha1",
     "github.com/crossplaneio/crossplane/apis/storage/v1alpha1",
-    "github.com/crossplaneio/crossplane/pkg/test",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/googleapis/gax-go",

--- a/gcp/apis/cache/v1alpha2/cloudmemorystore_instance_types_test.go
+++ b/gcp/apis/cache/v1alpha2/cloudmemorystore_instance_types_test.go
@@ -26,10 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	localtest "github.com/crossplaneio/stack-gcp/pkg/test"
+
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
-	localtest "github.com/crossplaneio/crossplane/pkg/test"
 )
 
 const (

--- a/gcp/apis/compute/v1alpha2/types_test.go
+++ b/gcp/apis/compute/v1alpha2/types_test.go
@@ -29,7 +29,8 @@ import (
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
-	localtest "github.com/crossplaneio/crossplane/pkg/test"
+
+	localtest "github.com/crossplaneio/stack-gcp/pkg/test"
 )
 
 const (

--- a/gcp/apis/database/v1alpha2/cloudsql_instance_types_test.go
+++ b/gcp/apis/database/v1alpha2/cloudsql_instance_types_test.go
@@ -32,7 +32,8 @@ import (
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
-	localtest "github.com/crossplaneio/crossplane/pkg/test"
+
+	localtest "github.com/crossplaneio/stack-gcp/pkg/test"
 )
 
 const (

--- a/gcp/apis/storage/v1alpha2/types_test.go
+++ b/gcp/apis/storage/v1alpha2/types_test.go
@@ -32,7 +32,8 @@ import (
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
-	localtest "github.com/crossplaneio/crossplane/pkg/test"
+
+	localtest "github.com/crossplaneio/stack-gcp/pkg/test"
 )
 
 const namespace = "default"

--- a/gcp/apis/v1alpha2/types_test.go
+++ b/gcp/apis/v1alpha2/types_test.go
@@ -28,7 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
-	localtest "github.com/crossplaneio/crossplane/pkg/test"
+
+	localtest "github.com/crossplaneio/stack-gcp/pkg/test"
 )
 
 const (

--- a/pkg/test/crds.go
+++ b/pkg/test/crds.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	_, b, _, _ = runtime.Caller(0)
+	crds       = filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(b))), "config", "crd")
+)
+
+// CRDs path to project crds location
+func CRDs() string {
+	return crds
+}


### PR DESCRIPTION
### Description of your changes
This was missed in the original porting from the main crossplane repo.  The API unit tests need to know where to find the CRDs at test runtime.  Each repo should have its own implementation of that, specific to the location of CRDs for the local repo.

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml