### PR TITLE
Get official builds running for stack-gcp repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
             steps {
                 script {
                     if (env.CHANGE_ID != null) {
-                        def json = sh (script: "curl -s https://api.github.com/repos/crossplaneio/crossplane/pulls/${env.CHANGE_ID}", returnStdout: true).trim()
+                        def json = sh (script: "curl -s https://api.github.com/repos/crossplaneio/stack-gcp/pulls/${env.CHANGE_ID}", returnStdout: true).trim()
                         def body = evaluateJson(json,'${json.body}')
                         if (body.contains("[skip ci]")) {
                             echo ("'[skip ci]' spotted in PR body text.")
@@ -51,26 +51,6 @@ pipeline {
             post {
                 always {
                     archiveArtifacts "_output/lint/**/*"
-                    ViolationsToGitHub([
-                        gitHubUrl: env.GIT_URL,
-                        repositoryName: env.REPOSITORY_NAME,
-                        repositoryOwner: env.REPOSITORY_OWNER,
-                        pullRequestId: env.CHANGE_ID,
-                        oAuth2Token: env.GITHUB_UPBOUND_BOT_PSW,
-
-                        createCommentWithAllSingleFileComments: false,
-                        createSingleFileComments: true,
-                        keepOldComments: false,
-                        commentOnlyChangedContent: true,
-                        commentTemplate: readFile('hack/linter-violation.tmpl'),
-
-                        violationConfigs: [[
-                            reporter: 'make lint',
-                            parser: 'CHECKSTYLE',
-                            // This is a regex run against the absolute path of the file.
-                            pattern: '.*/_output/lint/.+/checkstyle\\.xml\$',
-                        ]]
-                    ])
                 }
             }
         }
@@ -104,51 +84,6 @@ pipeline {
                             onlyStable: false,
                             sourceEncoding: 'ASCII',
                             zoomCoverageChart: false
-                }
-            }
-        }
-
-        stage("Integration Tests"){
-            when {
-                expression {
-                    return env.shouldBuild != "false"
-                }
-            }
-            steps {
-                sh './build/run make -j\$(nproc) e2e'
-            }
-        }
-
-        stage('SonarQube Analysis') {
-            when {
-                expression {
-                    return env.shouldBuild != "false"
-                }
-            }
-            steps {
-                script {
-                    scannerHome = tool 'SonarQubeScanner'
-                    scannerParams = ''
-                    if (env.CHANGE_ID == null) {
-                        scannerParams = "-Dsonar.branch.name=${BRANCH_NAME} "
-                        if (BRANCH_NAME != 'master') {
-                            scannerParams = "${scannerParams} -Dsonar.branch.target=master"
-                        }
-                    } else {
-                        scannerParams = "-Dsonar.pullrequest.base=master " +
-                            "-Dsonar.pullrequest.branch=${env.BRANCH_NAME} " +
-                            "-Dsonar.pullrequest.key=${env.CHANGE_ID}  " +
-                            "-Dsonar.pullrequest.provider=github " +
-                            "-Dsonar.pullrequest.github.repository=crossplaneio/${env.REPOSITORY_NAME}"
-                    }
-                }
-
-                withSonarQubeEnv('SonarQubeCrossplane') {
-                  sh "${scannerHome}/bin/sonar-scanner " +
-                    "-Dsonar.projectKey=crossplaneio_${env.REPOSITORY_NAME} " +
-                    "-Dsonar.projectName=${env.REPOSITORY_NAME} " +
-                    "-Dsonar.organization=crossplane " +
-                    "-Dsonar.sources=. ${scannerParams} "
                 }
             }
         }
@@ -220,8 +155,8 @@ pipeline {
 
 @NonCPS
 def evaluateJson(String json, String gpath){
-    //parse json
+    // parse json
     def ojson = new groovy.json.JsonSlurper().parseText(json)
-    //evaluate gpath as a gstring template where $json is a parsed json parameter
+    // evaluate gpath as a gstring template where $json is a parsed json parameter
     return new groovy.text.GStringTemplateEngine().createTemplate(gpath).make(json:ojson).toString()
 }

--- a/pkg/controller/gcp/compute/network.go
+++ b/pkg/controller/gcp/compute/network.go
@@ -181,7 +181,7 @@ func (c *networkExternal) Delete(ctx context.Context, mg resource.Managed) error
 	_, err := c.Networks.Delete(c.projectID, cr.Spec.Name).
 		Context(ctx).
 		Do()
-	if !clients.IsErrorNotFound(err) {
+	if clients.IsErrorNotFound(err) {
 		return nil
 	}
 	cr.Status.SetConditions(runtimev1alpha1.Deleting())


### PR DESCRIPTION
### Description of your changes
This PR is attempting to get official builds running on Jenkins in a new stack-gcp pipeline: https://jenkinsci.upbound.io/blue/organizations/jenkins/crossplane%2Fstack-gcp/activity

We'll want to have the same full functionality that the main crossplane repo has, such as SonarCloud checks and Integration tests, but I'm stripping the Jenkinsfile down for now just to get the build pipeline off the ground.

### Checklist
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml