### PR TITLE
DO NOT MERGE: test commit to see if lint failures cause Jenkins build failures

### DIFF
--- a/gcp/apis/compute/v1alpha2/subnetwork_types.go
+++ b/gcp/apis/compute/v1alpha2/subnetwork_types.go
@@ -161,7 +161,6 @@ type GCPSubnetworkSpec struct {
 // IsSameAs compares the fields of GCPSubnetworkSpec and
 // GCPSubnetworkStatus to report whether there is a difference. Its cyclomatic
 // complexity is related to how many fields exist, so, not much of an indicator.
-// nolint:gocyclo
 func (s GCPSubnetworkSpec) IsSameAs(o GCPSubnetworkStatus) bool {
 	if s.Name != o.Name ||
 		s.Description != o.Description ||
@@ -190,8 +189,6 @@ func (s GCPSubnetworkSpec) IsSameAs(o GCPSubnetworkStatus) bool {
 	return true
 }
 
-// GCPSubnetworkStatus is the complete mirror of googlecompute.Subnetwork but
-// with deepcopy functions. In the future, this can be generated automatically.
 type GCPSubnetworkStatus struct {
 	// CreationTimestamp: Creation timestamp in RFC3339 text
 	// format.


### PR DESCRIPTION
### Description of your changes
DO NOT MERGE, this is simply a test to verify that the Jenkins official builds will fail a PR if linting errors are found.  Intentional linting errors are added in this PR.