### PR TITLE
Use PrivateIP of CloudSQL if available and force send PublicIP setting

### DIFF
--- a/config/crd/database.gcp.crossplane.io_cloudsqlinstanceclasses.yaml
+++ b/config/crd/database.gcp.crossplane.io_cloudsqlinstanceclasses.yaml
@@ -52,6 +52,10 @@ spec:
               description: The database engine (MySQL or PostgreSQL) and its specific
                 version to use, e.g., MYSQL_5_7 or POSTGRES_9_6.
               type: string
+            ipv4Enabled:
+              description: 'Ipv4Enabled: Whether the instance should be assigned an
+                IP address or not.'
+              type: boolean
             labels:
               additionalProperties:
                 type: string

--- a/config/crd/database.gcp.crossplane.io_cloudsqlinstances.yaml
+++ b/config/crd/database.gcp.crossplane.io_cloudsqlinstances.yaml
@@ -132,6 +132,10 @@ spec:
               description: The database engine (MySQL or PostgreSQL) and its specific
                 version to use, e.g., MYSQL_5_7 or POSTGRES_9_6.
               type: string
+            ipv4Enabled:
+              description: 'Ipv4Enabled: Whether the instance should be assigned an
+                IP address or not.'
+              type: boolean
             labels:
               additionalProperties:
                 type: string

--- a/gcp/apis/database/v1alpha2/cloudsql_instance_types_test.go
+++ b/gcp/apis/database/v1alpha2/cloudsql_instance_types_test.go
@@ -135,6 +135,7 @@ func TestCloudsqlInstance_DatabaseInstance(t *testing.T) {
 				Settings: &sqladmin.Settings{
 					IpConfiguration: &sqladmin.IpConfiguration{
 						AuthorizedNetworks: []*sqladmin.AclEntry{},
+						ForceSendFields:    []string{"Ipv4Enabled"},
 					},
 				},
 			},
@@ -166,6 +167,7 @@ func TestCloudsqlInstance_DatabaseInstance(t *testing.T) {
 							{Value: "foo"},
 							{Value: "bar"},
 						},
+						ForceSendFields: []string{"Ipv4Enabled"},
 					},
 					Tier:       "test-tier",
 					UserLabels: map[string]string{"fooz": "booz"},

--- a/pkg/controller/gcp/compute/network_test.go
+++ b/pkg/controller/gcp/compute/network_test.go
@@ -62,7 +62,6 @@ const testGCPCredentialsJSON = `
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/crossplane-test%40crossplane-test.iam.gserviceaccount.com"
 }
-
 `
 
 func TestNetworkConnector_Connect(t *testing.T) {

--- a/pkg/controller/gcp/database/operations.go
+++ b/pkg/controller/gcp/database/operations.go
@@ -144,7 +144,6 @@ func (h *localHandler) updateConnectionSecret(ctx context.Context) (*corev1.Secr
 		s.Data[v1alpha2.PrivateIPKey] = secret.Data[v1alpha2.PrivateIPKey]
 		s.Data[v1alpha2.PublicIPKey] = secret.Data[v1alpha2.PublicIPKey]
 		s.Data[runtimev1alpha1.ResourceCredentialsSecretUserKey] = secret.Data[runtimev1alpha1.ResourceCredentialsSecretUserKey]
-		// NOTE: this is for backward compatibility. Please use PublicIPKey going forward.
 		s.Data[runtimev1alpha1.ResourceCredentialsSecretEndpointKey] = secret.Data[runtimev1alpha1.ResourceCredentialsSecretEndpointKey]
 		return nil
 	}); err != nil {

--- a/pkg/controller/gcp/database/operations_test.go
+++ b/pkg/controller/gcp/database/operations_test.go
@@ -867,7 +867,7 @@ func Test_localHandler_updateConnectionSecret(t *testing.T) {
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
 						assertKey(key)
 						s := assertObj(obj)
-						ts := testSecret("test-pub", "test-priv", "test-pub", "test-pass")
+						ts := testSecret("test-priv", "test-priv", "test-pub", "test-pass")
 						ts.DeepCopyInto(s)
 						return nil
 					},
@@ -878,7 +878,7 @@ func Test_localHandler_updateConnectionSecret(t *testing.T) {
 				},
 			},
 			want: want{
-				sec: testSecret("new-test-pub", "new-test-priv", "new-test-pub", "test-pass"),
+				sec: testSecret("new-test-priv", "new-test-priv", "new-test-pub", "test-pass"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

- Always use Private IP of CloudSQL instance as endpoint in connection secret, if it is available.
- Enforce IPv4Enabled setting of CloudSQL to be sent to GCP no matter the value.

The defaults in GCP do not match with Golang zero values. What happens is that we set a field to its zero-value but GCP client doesn't include that field in the REST call, for some fields the default that GCP uses is a non-zero value. `IPv4Enabled bool` field is an example for this. If we don't _force send_ that field, GCP decides that its value is _true_ and assigns a Public IP for the instance. We have encountered a similar problem with `Network` type as well, opened https://github.com/crossplaneio/stack-gcp/issues/15
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml