### PR TITLE
bump stack version to v0.1.0

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -21,7 +21,7 @@ readme: |
 # Version of project (optional)
 # If omitted the version will be filled with the docker tag
 # If set it must match the docker tag
-version: 0.0.1
+version: v0.1.0
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/install.yaml
+++ b/config/stack/manifests/install.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: "stack-gcp-controller"
-        image: "crossplane/stack-gcp:master"
+        image: "crossplane/stack-gcp:v0.1.0"
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
### Description of your changes

This PR bumps the stack version to v0.1.0 in both `app.yaml` and `install.yaml` in the `release-0.1` branch.  We will need to figure out a more automated experience for the versioning of stacks in the next release.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml