### PR TITLE
GKE: Handle cluster in error state and reflect error message to status 

### DIFF
--- a/apis/compute/v1alpha2/gkecluster_types.go
+++ b/apis/compute/v1alpha2/gkecluster_types.go
@@ -26,6 +26,7 @@ import (
 const (
 	ClusterStateProvisioning = "PROVISIONING"
 	ClusterStateRunning      = "RUNNING"
+	ClusterStateError        = "ERROR"
 )
 
 // Defaults for GKE resources.

--- a/pkg/controller/compute/gke.go
+++ b/pkg/controller/compute/gke.go
@@ -195,6 +195,7 @@ func (r *Reconciler) _sync(instance *gcpcomputev1alpha2.GKECluster, client gke.C
 	}
 
 	if cluster.Status == gcpcomputev1alpha2.ClusterStateError {
+		instance.Status.State = gcpcomputev1alpha2.ClusterStateError
 		return r.fail(instance, fmt.Errorf(erroredClusterErrorMessageFormat, cluster.Status, cluster.StatusMessage))
 	}
 

--- a/pkg/controller/compute/gke.go
+++ b/pkg/controller/compute/gke.go
@@ -54,7 +54,8 @@ const (
 	requeueOnWait   = 30 * time.Second
 	requeueOnSucces = 2 * time.Minute
 
-	updateErrorMessageFormat = "failed to update cluster object: %s"
+	updateErrorMessageFormat         = "failed to update cluster object: %s"
+	erroredClusterErrorMessageFormat = "gke cluster is in %s state with message: %s"
 )
 
 var (
@@ -191,6 +192,10 @@ func (r *Reconciler) _sync(instance *gcpcomputev1alpha2.GKECluster, client gke.C
 	cluster, err := client.GetCluster(instance.Spec.Zone, instance.Status.ClusterName)
 	if err != nil {
 		return r.fail(instance, err)
+	}
+
+	if cluster.Status == gcpcomputev1alpha2.ClusterStateError {
+		return r.fail(instance, fmt.Errorf(erroredClusterErrorMessageFormat, cluster.Status, cluster.StatusMessage))
 	}
 
 	if cluster.Status != gcpcomputev1alpha2.ClusterStateRunning {

--- a/pkg/controller/compute/gke_test.go
+++ b/pkg/controller/compute/gke_test.go
@@ -19,6 +19,7 @@ package compute
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/crossplaneio/stack-gcp/apis"
@@ -38,6 +39,8 @@ import (
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
+
+	gcpcomputev1alpha2 "github.com/crossplaneio/stack-gcp/apis/compute/v1alpha2"
 
 	. "github.com/crossplaneio/stack-gcp/apis/compute/v1alpha2"
 	"github.com/crossplaneio/stack-gcp/pkg/clients/fake"
@@ -116,6 +119,39 @@ func TestSyncClusterGetError(t *testing.T) {
 
 	expectedStatus := runtimev1alpha1.ConditionedStatus{}
 	expectedStatus.SetConditions(runtimev1alpha1.ReconcileError(testError))
+
+	rs, err := r._sync(tc, cl)
+	g.Expect(rs).To(Equal(resultRequeue))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(called).To(BeTrue())
+	assertResource(g, r, expectedStatus)
+}
+
+func TestSyncErroredCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tc := testCluster()
+
+	r := &Reconciler{
+		Client:     NewFakeClient(tc),
+		kubeclient: NewSimpleClientset(),
+	}
+
+	errorMessage := "Something went wrong on gcloud side."
+
+	called := false
+
+	cl := fake.NewGKEClient()
+	cl.MockGetCluster = func(string, string) (*container.Cluster, error) {
+		called = true
+		return &container.Cluster{
+			Status:        ClusterStateError,
+			StatusMessage: errorMessage,
+		}, nil
+	}
+
+	expectedStatus := runtimev1alpha1.ConditionedStatus{}
+	expectedStatus.SetConditions(runtimev1alpha1.ReconcileError(fmt.Errorf(erroredClusterErrorMessageFormat, gcpcomputev1alpha2.ClusterStateError, errorMessage)))
 
 	rs, err := r._sync(tc, cl)
 	g.Expect(rs).To(Equal(resultRequeue))

--- a/pkg/controller/compute/gke_test.go
+++ b/pkg/controller/compute/gke_test.go
@@ -151,12 +151,14 @@ func TestSyncErroredCluster(t *testing.T) {
 	}
 
 	expectedStatus := runtimev1alpha1.ConditionedStatus{}
+	expectedState := ClusterStateError
 	expectedStatus.SetConditions(runtimev1alpha1.ReconcileError(fmt.Errorf(erroredClusterErrorMessageFormat, gcpcomputev1alpha2.ClusterStateError, errorMessage)))
 
 	rs, err := r._sync(tc, cl)
 	g.Expect(rs).To(Equal(resultRequeue))
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(called).To(BeTrue())
+	g.Expect(tc.Status.State).To(Equal(expectedState))
 	assertResource(g, r, expectedStatus)
 }
 


### PR DESCRIPTION
if gke cluster is in error state on gke side, error message is not
reflected to managed resource status. This commit reflects the error
message to status and sets status.state as ERROR.

Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Currently the error message from gcloud api is not reflected to GKECluster managed resource status when cluster is in "ERROR" state. Hence the actual error can only be seen via gcloud client or console. 
This PR adds an appropriate error message to status and sets condition as "ERROR". 
Example:

```
...
status:
  clusterName: gke-ae97d287-7e4d-4c9b-921c-b14d27396d97
  conditions:
  - lastTransitionTime: "2019-10-07T10:59:01Z"
    reason: Managed resource is being created
    status: "False"
    type: Ready
  - lastTransitionTime: "2019-10-07T13:23:06Z"
    message: 'gke cluster is in ERROR state with message: Retry budget exhausted (10
      attempts): Services range "services" in network "example-network", subnetwork
      "example-subnetwork" is already used by another cluster.'
    reason: Encountered an error during managed resource reconciliation
    status: "False"
    type: Synced
  endpoint: ""
  state: ERROR
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml