### PR TITLE
cloudsql: fix up-to-date check bug

### DIFF
--- a/pkg/clients/cloudsql/cloudsql.go
+++ b/pkg/clients/cloudsql/cloudsql.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudsql
 
 import (
+	"reflect"
 	"strings"
 
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
@@ -275,6 +276,14 @@ func LateInitializeSpec(spec *v1beta1.CloudsqlInstanceParameters, in sqladmin.Da
 			}
 		}
 	}
+}
+
+// IsUpToDate checks whether current state is up-to-date compared to the given
+// set of parameters.
+func IsUpToDate(in *v1beta1.CloudsqlInstanceParameters, currentState sqladmin.DatabaseInstance) bool {
+	currentParams := &v1beta1.CloudsqlInstanceParameters{}
+	LateInitializeSpec(currentParams, currentState)
+	return reflect.DeepEqual(in, currentParams)
 }
 
 // DatabaseUserName returns default database user name base on database version

--- a/pkg/controller/database/cloudsql.go
+++ b/pkg/controller/database/cloudsql.go
@@ -124,8 +124,7 @@ func (c *cloudsqlExternal) Observe(ctx context.Context, mg resource.Managed) (re
 	cloudsql.LateInitializeSpec(&cr.Spec.ForProvider, *instance)
 	// TODO(muvaf): reflection in production code might cause performance bottlenecks. Generating comparison
 	// methods would make more sense.
-	upToDate := reflect.DeepEqual(currentSpec, &cr.Spec.ForProvider)
-	if !upToDate {
+	if !reflect.DeepEqual(currentSpec, &cr.Spec.ForProvider) {
 		if err := c.kube.Update(ctx, cr); err != nil {
 			return resource.ExternalObservation{}, errors.Wrap(err, errManagedUpdateFailed)
 		}
@@ -141,7 +140,7 @@ func (c *cloudsqlExternal) Observe(ctx context.Context, mg resource.Managed) (re
 	}
 	return resource.ExternalObservation{
 		ResourceExists:    true,
-		ResourceUpToDate:  upToDate,
+		ResourceUpToDate:  cloudsql.IsUpToDate(&cr.Spec.ForProvider, *instance),
 		ConnectionDetails: getConnectionDetails(cr, instance),
 	}, nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Up-to-date check implementation was buggy. It compared _current params + late-init_ with current state. But it should actually compare _empty params + late-init_ with the current state. It always returned `true` until this PR.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
