### PR TITLE
cloudmemorystore: propagate port to connection secret

### DIFF
--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -128,6 +129,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (resource.E
 	case cloudmemorystore.StateReady:
 		cr.Status.SetConditions(runtimev1alpha1.Available())
 		conn[runtimev1alpha1.ResourceCredentialsSecretEndpointKey] = []byte(cr.Status.AtProvider.Host)
+		conn[runtimev1alpha1.ResourceCredentialsSecretPortKey] = []byte(strconv.Itoa(int(cr.Status.AtProvider.Port)))
 		resource.SetBindable(cr)
 	case cloudmemorystore.StateCreating:
 		cr.Status.SetConditions(runtimev1alpha1.Creating())

--- a/pkg/controller/cache/managed_test.go
+++ b/pkg/controller/cache/managed_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	redisv1 "cloud.google.com/go/redis/apiv1"
@@ -300,6 +301,7 @@ func TestObserve(t *testing.T) {
 					ResourceExists: true,
 					ConnectionDetails: resource.ConnectionDetails{
 						runtimev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(host),
+						runtimev1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(port)),
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Propagate port to connection secret using new port constant from crossplane-runtime.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
