### PR TITLE
build: new Jenkinsfiles for tagging and promoting releases

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -1,0 +1,37 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example v0.4.0')
+        string(name: 'channel', defaultValue: 'alpha', description: 'Channel you are promoting the given version to, for example alpha.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        AWS = credentials('aws-upbound-bot')
+    }
+
+    stages {
+        stage('Promote Release') {
+
+            steps {
+                sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+                sh "./build/run make -j\$(nproc) promote BRANCH_NAME=${BRANCH_NAME} VERSION=${params.version} CHANNEL=${params.channel} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}"
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,42 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example v0.4.0')
+        string(name: 'commit', defaultValue: '', description: 'Optional commit hash for this release, for example 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty the latest commit hash will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                sh "./build/run make -j\$(nproc) tag VERSION=${params.version} COMMIT_HASH=${params.commit}"
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}


### PR DESCRIPTION
### Description of your changes

This PR adds 2 new Jenkinsfiles that will be used as part of the release process.  `Jenkinsfile.tag` will tag commits with a specific release version.  `Jenkinsfile.promote` will promote a specific release version to a specific channel.  See more details in the [release engineering design doc](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-release-process.md#pipeline-improvements).

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
