### PR TITLE
improve error message when instance name is in use

### DIFF
--- a/pkg/controller/database/cloudsql.go
+++ b/pkg/controller/database/cloudsql.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	googleapi "google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 	v1 "k8s.io/api/core/v1"
@@ -49,6 +50,7 @@ const (
 
 	errNewClient        = "cannot create new Sqladmin Service"
 	errCreateFailed     = "cannot create new CloudSQL instance"
+	errNameInUse        = "cannot create new CloudSQL instance, the name %s is unavailable because it is in use or was used recently"
 	errDeleteFailed     = "cannot delete the CloudSQL instance"
 	errUpdateFailed     = "cannot update the CloudSQL instance"
 	errGetFailed        = "cannot get the CloudSQL instance"
@@ -161,6 +163,9 @@ func (c *cloudsqlExternal) Create(ctx context.Context, mg resource.Managed) (res
 	if _, err := c.db.Insert(c.projectID, instance).Context(ctx).Do(); err != nil {
 		// We don't want to return (and thus publish) our randomly generated
 		// password if we didn't actually successfully create a new instance.
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 409 {
+			return resource.ExternalCreation{}, errors.Wrapf(err, errNameInUse, instance.Name)
+		}
 		return resource.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}
 

--- a/pkg/controller/database/cloudsql_test.go
+++ b/pkg/controller/database/cloudsql_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -494,7 +493,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				mg:  instance(withConditions(runtimev1alpha1.Creating())),
-				err: errors.Wrap(gError(http.StatusConflict, ""), fmt.Sprintf(errNameInUse, instance().Name)),
+				err: errors.Wrap(gError(http.StatusConflict, ""), errNameInUse),
 			},
 		},
 		"Failed": {
@@ -552,6 +551,7 @@ func TestCreate(t *testing.T) {
 				}
 
 				if bv == wantRandom {
+					return len(av) > 0
 					return len(av) > 0
 				}
 

--- a/pkg/controller/database/cloudsql_test.go
+++ b/pkg/controller/database/cloudsql_test.go
@@ -552,7 +552,6 @@ func TestCreate(t *testing.T) {
 
 				if bv == wantRandom {
 					return len(av) > 0
-					return len(av) > 0
 				}
 
 				return cmp.Equal(a, b)

--- a/pkg/controller/database/cloudsql_test.go
+++ b/pkg/controller/database/cloudsql_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -493,7 +494,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				mg:  instance(withConditions(runtimev1alpha1.Creating())),
-				err: errors.Wrap(gError(http.StatusConflict, ""), errCreateFailed),
+				err: errors.Wrap(gError(http.StatusConflict, ""), fmt.Sprintf(errNameInUse, instance().Name)),
 			},
 		},
 		"Failed": {


### PR DESCRIPTION
### Description of your changes

Fixes #100

When trying to create a SQL Instance with a name that is already
in use, we returned a more or less generic "create failed" error
message and the return code 409. As 409 indicates that the name
of the SQL instance is in use or has been in use recently, this
commit improves the message that is returned to the user.

### Checklist

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
   -> `make: *** No rule to make target "generate", needed by "reviewable".  Stop.`
          Local `go test` is running through fine though 🙂 
- [x] Ensured this PR contains a neat, self documenting set of commits.
