### PR TITLE
integration tests: fix leaked goroutines

### DIFF
--- a/test/integration/gkecluster_static_test.go
+++ b/test/integration/gkecluster_static_test.go
@@ -59,16 +59,18 @@ func TestGKEClusterStatic(t *testing.T) {
 				}
 
 				defer func() {
-					if err := waitFor(context.Background(), 10*time.Second, func(ch chan error) {
+					if err := waitFor(context.Background(), 10*time.Second, func() (bool, error) {
 						err := c.Delete(context.Background(), g)
 
 						if kerrors.IsNotFound(err) {
-							ch <- nil
+							return true, nil
 						}
 
 						if err != nil {
-							ch <- err
+							return true, err
 						}
+
+						return false, nil
 					}); err != nil {
 						t.Error(err)
 					}
@@ -86,15 +88,17 @@ func TestGKEClusterStatic(t *testing.T) {
 					return err
 				}
 
-				return waitFor(ctx, 10*time.Second, func(ch chan error) {
+				return waitFor(ctx, 10*time.Second, func() (bool, error) {
 					to := &containerv1beta1.GKECluster{}
 					if err := c.Get(ctx, types.NamespacedName{Name: g.Name}, to); err != nil {
-						ch <- err
+						return true, err
 					}
 
 					if to.Status.AtProvider.Status == containerv1beta1.ClusterStateRunning {
-						ch <- nil
+						return true, nil
 					}
+
+					return false, nil
 				})
 			},
 		},


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

@suskin caught some issues in the `waitFor` function that was being used in integration tests to observe created resources in the cluster. This PR fixes the both the leaking of goroutines and also implements the wait interval as expected.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [ ] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/resources
