### PR TITLE
Fix resource claim kinds in controller names

### DIFF
--- a/pkg/controller/cache/claim.go
+++ b/pkg/controller/cache/claim.go
@@ -43,7 +43,7 @@ import (
 // class and resource references by picking a random matching
 // CloudMemorystoreInstanceClass, if any.
 func SetupCloudMemorystoreInstanceClaimScheduling(mgr ctrl.Manager, l logging.Logger) error {
-	name := claimscheduling.ControllerName(v1beta1.CloudMemorystoreInstanceKind)
+	name := claimscheduling.ControllerName(cachev1alpha1.RedisClusterKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -66,7 +66,7 @@ func SetupCloudMemorystoreInstanceClaimScheduling(mgr ctrl.Manager, l logging.Lo
 // class selector by choosing a default CloudMemorystoreInstanceClass if one
 // exists.
 func SetupCloudMemorystoreInstanceClaimDefaulting(mgr ctrl.Manager, l logging.Logger) error {
-	name := claimdefaulting.ControllerName(v1beta1.CloudMemorystoreInstanceKind)
+	name := claimdefaulting.ControllerName(cachev1alpha1.RedisClusterKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -88,7 +88,7 @@ func SetupCloudMemorystoreInstanceClaimDefaulting(mgr ctrl.Manager, l logging.Lo
 // RedisCluster claims with CloudMemorystoreInstances, dynamically provisioning
 // them if needed.
 func SetupCloudMemorystoreInstanceClaimBinding(mgr ctrl.Manager, l logging.Logger) error {
-	name := claimbinding.ControllerName(v1beta1.CloudMemorystoreInstanceKind)
+	name := claimbinding.ControllerName(cachev1alpha1.RedisClusterKind)
 
 	p := resource.NewPredicates(resource.AnyOf(
 		resource.HasClassReferenceKind(resource.ClassKind(v1beta1.CloudMemorystoreInstanceClassGroupVersionKind)),

--- a/pkg/controller/compute/claim.go
+++ b/pkg/controller/compute/claim.go
@@ -39,7 +39,7 @@ import (
 // KubernetesCluster claims that include a class selector but omit their class
 // and resource references by picking a random matching GKEClusterClass, if any.
 func SetupGKEClusterClaimScheduling(mgr ctrl.Manager, l logging.Logger) error {
-	name := claimscheduling.ControllerName(v1alpha3.GKEClusterKind)
+	name := claimscheduling.ControllerName(computev1alpha1.KubernetesClusterKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -61,7 +61,7 @@ func SetupGKEClusterClaimScheduling(mgr ctrl.Manager, l logging.Logger) error {
 // KubernetesCluster claims that omit their resource ref, class ref, and class
 // selector by choosing a default GKEClusterClass if one exists.
 func SetupGKEClusterClaimDefaulting(mgr ctrl.Manager, l logging.Logger) error {
-	name := claimdefaulting.ControllerName(v1alpha3.GKEClusterKind)
+	name := claimdefaulting.ControllerName(computev1alpha1.KubernetesClusterKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -83,7 +83,7 @@ func SetupGKEClusterClaimDefaulting(mgr ctrl.Manager, l logging.Logger) error {
 // KubernetesCluster claims with GKEClusters, dynamically provisioning them if
 // needed.
 func SetupGKEClusterClaimBinding(mgr ctrl.Manager, l logging.Logger) error {
-	name := claimbinding.ControllerName(v1alpha3.GKEClusterKind)
+	name := claimbinding.ControllerName(computev1alpha1.KubernetesClusterKind)
 
 	p := resource.NewPredicates(resource.AnyOf(
 		resource.HasClassReferenceKind(resource.ClassKind(v1alpha3.GKEClusterClassGroupVersionKind)),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Claim controllers should use their claim kind, not managed resource kind, as their controller name. Typically there will be one one controller for each kind of resource claim per infrastructure stack.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [ ] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/resources
