### PR TITLE
Expose connectionName of CloudSQLInstance in connection secret

### DIFF
--- a/apis/database/v1beta1/cloudsql_instance_types.go
+++ b/apis/database/v1beta1/cloudsql_instance_types.go
@@ -51,6 +51,8 @@ const (
 	CloudSQLSecretServerCACertificateExpirationTimeKey   = "serverCACertificateExpirationTime"
 	CloudSQLSecretServerCACertificateInstanceKey         = "serverCACertificateInstance"
 	CloudSQLSecretServerCACertificateSha1FingerprintKey  = "serverCACertificateSha1Fingerprint"
+
+	CloudSQLSecretConnectionName = "connectionName"
 )
 
 // CloudSQL version prefixes.

--- a/pkg/controller/database/cloudsql.go
+++ b/pkg/controller/database/cloudsql.go
@@ -205,6 +205,7 @@ func (c *cloudsqlExternal) Delete(ctx context.Context, mg resource.Managed) erro
 func getConnectionDetails(cr *v1beta1.CloudSQLInstance, instance *sqladmin.DatabaseInstance) managed.ConnectionDetails {
 	m := managed.ConnectionDetails{
 		v1alpha1.ResourceCredentialsSecretUserKey: []byte(cloudsql.DatabaseUserName(cr.Spec.ForProvider)),
+		v1beta1.CloudSQLSecretConnectionName:      []byte(instance.ConnectionName),
 	}
 
 	// TODO(muvaf): There might be cases where more than 1 private and/or public IP address has been assigned. We should


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Expose connectionName in the connection secret to enable CloudSQL proxy connections.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/resources
