### PR TITLE
Cloudsql and Cloudmemoryinstance status update fix

### DIFF
--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -113,9 +113,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetInstance)
 	}
-
-	cr.Status.AtProvider = cloudmemorystore.GenerateObservation(*existing)
-
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	cloudmemorystore.LateInitializeSpec(&cr.Spec.ForProvider, *existing)
 	if !cmp.Equal(currentSpec, &cr.Spec.ForProvider) {
@@ -123,7 +120,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			return managed.ExternalObservation{}, errors.Wrap(err, errUpdateCR)
 		}
 	}
-
+	cr.Status.AtProvider = cloudmemorystore.GenerateObservation(*existing)
 	conn := managed.ConnectionDetails{}
 	switch cr.Status.AtProvider.State {
 	case cloudmemorystore.StateReady:

--- a/pkg/controller/database/cloudsql.go
+++ b/pkg/controller/database/cloudsql.go
@@ -120,7 +120,6 @@ func (c *cloudsqlExternal) Observe(ctx context.Context, mg resource.Managed) (ma
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(gcp.IsErrorNotFound, err), errGetFailed)
 	}
-	cr.Status.AtProvider = cloudsql.GenerateObservation(*instance)
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	cloudsql.LateInitializeSpec(&cr.Spec.ForProvider, *instance)
 	// TODO(muvaf): reflection in production code might cause performance bottlenecks. Generating comparison
@@ -130,6 +129,7 @@ func (c *cloudsqlExternal) Observe(ctx context.Context, mg resource.Managed) (ma
 			return managed.ExternalObservation{}, errors.Wrap(err, errManagedUpdateFailed)
 		}
 	}
+	cr.Status.AtProvider = cloudsql.GenerateObservation(*instance)
 	switch cr.Status.AtProvider.State {
 	case v1beta1.StateRunnable:
 		cr.Status.SetConditions(v1alpha1.Available())


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

When `Update` is called on a resource, the resulting object deep copied into what's sent, meaning `status` sub resource gets deleted. This shows itself in occasions where the controller constantly late-inits, which is rare, but when it does the status is emptied.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/resources
