### PR TITLE
Parameter structs should appear on top in API reference docs

### DIFF
--- a/apis/container/v1beta1/gkecluster_types.go
+++ b/apis/container/v1beta1/gkecluster_types.go
@@ -81,151 +81,9 @@ func (v *SubnetworkURIReferencerForGKECluster) Assign(res resource.CanReference,
 	return nil
 }
 
-// GKEClusterObservation is used to show the observed state of the GKE cluster resource on GCP.
-type GKEClusterObservation struct {
-	// Conditions: Which conditions caused the current cluster state.
-	Conditions []*StatusCondition `json:"conditions,omitempty"`
-
-	// CreateTime: The time the cluster was created,
-	// in
-	// [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.
-	CreateTime string `json:"createTime,omitempty"`
-
-	// CurrentMasterVersion: The current software version of
-	// the master endpoint.
-	CurrentMasterVersion string `json:"currentMasterVersion,omitempty"`
-
-	// CurrentNodeCount:  The number of nodes currently in the
-	// cluster. Deprecated.
-	// Call Kubernetes API directly to retrieve node information.
-	CurrentNodeCount int64 `json:"currentNodeCount,omitempty"`
-
-	// CurrentNodeVersion: Deprecated,
-	// use
-	// [NodePools.version](/kubernetes-engine/docs/reference/rest/v1/proj
-	// ects.zones.clusters.nodePools)
-	// instead. The current version of the node software components. If they
-	// are
-	// currently at multiple versions because they're in the process of
-	// being
-	// upgraded, this reflects the minimum version of all nodes.
-	CurrentNodeVersion string `json:"currentNodeVersion,omitempty"`
-
-	// Endpoint: The IP address of this cluster's master
-	// endpoint.
-	// The endpoint can be accessed from the internet
-	// at
-	// `https://username:password@endpoint/`.
-	//
-	// See the `masterAuth` property of this resource for username
-	// and
-	// password information.
-	Endpoint string `json:"endpoint,omitempty"`
-
-	// ExpireTime: The time the cluster will be
-	// automatically
-	// deleted in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text
-	// format.
-	ExpireTime string `json:"expireTime,omitempty"`
-
-	// Location: The name of the Google Compute
-	// Engine
-	// [zone](/compute/docs/regions-zones/regions-zones#available)
-	// or
-	// [region](/compute/docs/regions-zones/regions-zones#available) in
-	// which
-	// the cluster resides.
-	Location string `json:"location"`
-
-	// MaintenancePolicy: Configure the maintenance policy for this cluster.
-	MaintenancePolicy *MaintenancePolicyStatus `json:"maintenancePolicy,omitempty"`
-
-	// NetworkConfig: Configuration for cluster networking.
-	NetworkConfig *NetworkConfigStatus `json:"networkConfig,omitempty"`
-
-	// NodeIpv4CidrSize: The size of the address space on each
-	// node for hosting
-	// containers. This is provisioned from within the
-	// `container_ipv4_cidr`
-	// range. This field will only be set when cluster is in route-based
-	// network
-	// mode.
-	NodeIpv4CidrSize int64 `json:"nodeIpv4CidrSize,omitempty"`
-
-	// PrivateClusterConfig: Configuration for private cluster.
-	PrivateClusterConfig *PrivateClusterConfigStatus `json:"privateClusterConfig,omitempty"`
-
-	// NOTE(hasheddan): node pools are modelled in status only because
-	// management of node pools is handled by the stack-gcp NodePool object.
-
-	// NodePools: The node pools associated with this cluster.
-	// This field should not be set if "node_config" or "initial_node_count"
-	// are
-	// specified.
-	NodePools []*NodePoolClusterStatus `json:"nodePools,omitempty"`
-
-	// SelfLink: Server-defined URL for the resource.
-	SelfLink string `json:"selfLink,omitempty"`
-
-	// ServicesIpv4Cidr: The IP address range of the
-	// Kubernetes services in
-	// this cluster,
-	// in
-	// [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-	//
-	// notation (e.g. `1.2.3.4/29`). Service addresses are
-	// typically put in the last `/16` from the container CIDR.
-	ServicesIpv4Cidr string `json:"servicesIpv4Cidr,omitempty"`
-
-	// Status: The current status of this cluster.
-	//
-	// Possible values:
-	//   "STATUS_UNSPECIFIED" - Not set.
-	//   "PROVISIONING" - The PROVISIONING state indicates the cluster is
-	// being created.
-	//   "RUNNING" - The RUNNING state indicates the cluster has been
-	// created and is fully
-	// usable.
-	//   "RECONCILING" - The RECONCILING state indicates that some work is
-	// actively being done on
-	// the cluster, such as upgrading the master or node software. Details
-	// can
-	// be found in the `statusMessage` field.
-	//   "STOPPING" - The STOPPING state indicates the cluster is being
-	// deleted.
-	//   "ERROR" - The ERROR state indicates the cluster may be unusable.
-	// Details
-	// can be found in the `statusMessage` field.
-	//   "DEGRADED" - The DEGRADED state indicates the cluster requires user
-	// action to restore
-	// full functionality. Details can be found in the `statusMessage`
-	// field.
-	Status string `json:"status,omitempty"`
-
-	// StatusMessage: Additional information about the current
-	// status of this
-	// cluster, if available.
-	StatusMessage string `json:"statusMessage,omitempty"`
-
-	// TpuIpv4CidrBlock: The IP address range of the Cloud
-	// TPUs in this cluster,
-	// in
-	// [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-	//
-	// notation (e.g. `1.2.3.4/29`).
-	TpuIpv4CidrBlock string `json:"tpuIpv4CidrBlock,omitempty"`
-
-	// Zone: The name of the Google Compute
-	// Engine
-	// [zone](/compute/docs/zones#available) in which the
-	// cluster
-	// resides.
-	// This field is deprecated, use location instead.
-	Zone string `json:"zone,omitempty"`
-}
-
 // GKEClusterParameters define the desired state of a Google Kubernetes Engine
-// cluster.
+// cluster. Most of its fields are direct mirror of GCP Cluster object.
+// See https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster
 type GKEClusterParameters struct {
 	// NOTE(hasheddan): Location is labelled as Output Only by GCP but is required
 	// to create a cluster. It is not included in the actual cluster object
@@ -488,6 +346,149 @@ type GKEClusterParameters struct {
 	// policies.
 	// +optional
 	WorkloadIdentityConfig *WorkloadIdentityConfig `json:"workloadIdentityConfig,omitempty"`
+}
+
+// GKEClusterObservation is used to show the observed state of the GKE cluster resource on GCP.
+type GKEClusterObservation struct {
+	// Conditions: Which conditions caused the current cluster state.
+	Conditions []*StatusCondition `json:"conditions,omitempty"`
+
+	// CreateTime: The time the cluster was created,
+	// in
+	// [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format.
+	CreateTime string `json:"createTime,omitempty"`
+
+	// CurrentMasterVersion: The current software version of
+	// the master endpoint.
+	CurrentMasterVersion string `json:"currentMasterVersion,omitempty"`
+
+	// CurrentNodeCount:  The number of nodes currently in the
+	// cluster. Deprecated.
+	// Call Kubernetes API directly to retrieve node information.
+	CurrentNodeCount int64 `json:"currentNodeCount,omitempty"`
+
+	// CurrentNodeVersion: Deprecated,
+	// use
+	// [NodePools.version](/kubernetes-engine/docs/reference/rest/v1/proj
+	// ects.zones.clusters.nodePools)
+	// instead. The current version of the node software components. If they
+	// are
+	// currently at multiple versions because they're in the process of
+	// being
+	// upgraded, this reflects the minimum version of all nodes.
+	CurrentNodeVersion string `json:"currentNodeVersion,omitempty"`
+
+	// Endpoint: The IP address of this cluster's master
+	// endpoint.
+	// The endpoint can be accessed from the internet
+	// at
+	// `https://username:password@endpoint/`.
+	//
+	// See the `masterAuth` property of this resource for username
+	// and
+	// password information.
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// ExpireTime: The time the cluster will be
+	// automatically
+	// deleted in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text
+	// format.
+	ExpireTime string `json:"expireTime,omitempty"`
+
+	// Location: The name of the Google Compute
+	// Engine
+	// [zone](/compute/docs/regions-zones/regions-zones#available)
+	// or
+	// [region](/compute/docs/regions-zones/regions-zones#available) in
+	// which
+	// the cluster resides.
+	Location string `json:"location"`
+
+	// MaintenancePolicy: Configure the maintenance policy for this cluster.
+	MaintenancePolicy *MaintenancePolicyStatus `json:"maintenancePolicy,omitempty"`
+
+	// NetworkConfig: Configuration for cluster networking.
+	NetworkConfig *NetworkConfigStatus `json:"networkConfig,omitempty"`
+
+	// NodeIpv4CidrSize: The size of the address space on each
+	// node for hosting
+	// containers. This is provisioned from within the
+	// `container_ipv4_cidr`
+	// range. This field will only be set when cluster is in route-based
+	// network
+	// mode.
+	NodeIpv4CidrSize int64 `json:"nodeIpv4CidrSize,omitempty"`
+
+	// PrivateClusterConfig: Configuration for private cluster.
+	PrivateClusterConfig *PrivateClusterConfigStatus `json:"privateClusterConfig,omitempty"`
+
+	// NOTE(hasheddan): node pools are modelled in status only because
+	// management of node pools is handled by the stack-gcp NodePool object.
+
+	// NodePools: The node pools associated with this cluster.
+	// This field should not be set if "node_config" or "initial_node_count"
+	// are
+	// specified.
+	NodePools []*NodePoolClusterStatus `json:"nodePools,omitempty"`
+
+	// SelfLink: Server-defined URL for the resource.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// ServicesIpv4Cidr: The IP address range of the
+	// Kubernetes services in
+	// this cluster,
+	// in
+	// [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
+	//
+	// notation (e.g. `1.2.3.4/29`). Service addresses are
+	// typically put in the last `/16` from the container CIDR.
+	ServicesIpv4Cidr string `json:"servicesIpv4Cidr,omitempty"`
+
+	// Status: The current status of this cluster.
+	//
+	// Possible values:
+	//   "STATUS_UNSPECIFIED" - Not set.
+	//   "PROVISIONING" - The PROVISIONING state indicates the cluster is
+	// being created.
+	//   "RUNNING" - The RUNNING state indicates the cluster has been
+	// created and is fully
+	// usable.
+	//   "RECONCILING" - The RECONCILING state indicates that some work is
+	// actively being done on
+	// the cluster, such as upgrading the master or node software. Details
+	// can
+	// be found in the `statusMessage` field.
+	//   "STOPPING" - The STOPPING state indicates the cluster is being
+	// deleted.
+	//   "ERROR" - The ERROR state indicates the cluster may be unusable.
+	// Details
+	// can be found in the `statusMessage` field.
+	//   "DEGRADED" - The DEGRADED state indicates the cluster requires user
+	// action to restore
+	// full functionality. Details can be found in the `statusMessage`
+	// field.
+	Status string `json:"status,omitempty"`
+
+	// StatusMessage: Additional information about the current
+	// status of this
+	// cluster, if available.
+	StatusMessage string `json:"statusMessage,omitempty"`
+
+	// TpuIpv4CidrBlock: The IP address range of the Cloud
+	// TPUs in this cluster,
+	// in
+	// [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
+	//
+	// notation (e.g. `1.2.3.4/29`).
+	TpuIpv4CidrBlock string `json:"tpuIpv4CidrBlock,omitempty"`
+
+	// Zone: The name of the Google Compute
+	// Engine
+	// [zone](/compute/docs/zones#available) in which the
+	// cluster
+	// resides.
+	// This field is deprecated, use location instead.
+	Zone string `json:"zone,omitempty"`
 }
 
 // AddonsConfig is configuration for the addons that can be automatically

--- a/apis/database/v1beta1/cloudsql_instance_types.go
+++ b/apis/database/v1beta1/cloudsql_instance_types.go
@@ -138,84 +138,9 @@ func (v *NetworkURIReferencerForCloudSQLInstance) Assign(res resource.CanReferen
 	return nil
 }
 
-// CloudSQLInstanceObservation is used to show the observed state of the Cloud SQL resource on GCP.
-type CloudSQLInstanceObservation struct {
-	// BackendType: FIRST_GEN: First Generation instance. MySQL
-	// only.
-	// SECOND_GEN: Second Generation instance or PostgreSQL
-	// instance.
-	// EXTERNAL: A database server that is not managed by Google.
-	// This property is read-only; use the tier property in the settings
-	// object to determine the database type and Second or First Generation.
-	BackendType string `json:"backendType,omitempty"`
-
-	// CurrentDiskSize: The current disk usage of the instance in bytes.
-	// This property has been deprecated. Users should use the
-	// "cloudsql.googleapis.com/database/disk/bytes_used" metric in Cloud
-	// Monitoring API instead. Please see this announcement for details.
-	CurrentDiskSize int64 `json:"currentDiskSize,omitempty"`
-
-	// ConnectionName: Connection name of the Cloud SQL instance used in
-	// connection strings.
-	ConnectionName string `json:"connectionName,omitempty"`
-
-	// DiskEncryptionStatus: Disk encryption status specific to an instance.
-	// Applies only to Second Generation instances.
-	DiskEncryptionStatus *DiskEncryptionStatus `json:"diskEncryptionStatus,omitempty"`
-
-	// FailoverReplica: The name and status of the failover replica. This
-	// property is applicable only to Second Generation instances.
-	FailoverReplica *DatabaseInstanceFailoverReplicaStatus `json:"failoverReplica,omitempty"`
-
-	// GceZone: The Compute Engine zone that the instance is currently
-	// serving from. This value could be different from the zone that was
-	// specified when the instance was created if the instance has failed
-	// over to its secondary zone.
-	GceZone string `json:"gceZone,omitempty"`
-
-	// IPAddresses: The assigned IP addresses for the instance.
-	IPAddresses []*IPMapping `json:"ipAddresses,omitempty"`
-
-	// IPv6Address: The IPv6 address assigned to the instance. This property
-	// is applicable only to First Generation instances.
-	IPv6Address string `json:"ipv6Address,omitempty"`
-
-	// Project: The project ID of the project containing the Cloud SQL
-	// instance. The Google apps domain is prefixed if applicable.
-	Project string `json:"project,omitempty"`
-
-	// SelfLink: The URI of this resource.
-	SelfLink string `json:"selfLink,omitempty"`
-
-	// ServiceAccountEmailAddress: The service account email address
-	// assigned to the instance. This property is applicable only to Second
-	// Generation instances.
-	ServiceAccountEmailAddress string `json:"serviceAccountEmailAddress,omitempty"`
-
-	// State: The current serving state of the Cloud SQL instance. This can
-	// be one of the following.
-	// RUNNABLE: The instance is running, or is ready to run when
-	// accessed.
-	// SUSPENDED: The instance is not available, for example due to problems
-	// with billing.
-	// PENDING_CREATE: The instance is being created.
-	// MAINTENANCE: The instance is down for maintenance.
-	// FAILED: The instance creation failed.
-	// UNKNOWN_STATE: The state of the instance is unknown.
-	State string `json:"state,omitempty"`
-
-	// NOTE(muvaf): This comes from Settings sub-struct, not directly from
-	// DatabaseInstance struct.
-
-	// SettingsVersion: The version of instance settings. This is a required
-	// field for update method to make sure concurrent updates are handled
-	// properly. During update, use the most recent settingsVersion value
-	// for this instance and do not try to update this value.
-	SettingsVersion int64 `json:"settingsVersion,omitempty"`
-}
-
 // CloudSQLInstanceParameters define the desired state of a Google CloudSQL
-// instance.
+// instance. Most of its fields are direct mirror of GCP DatabaseInstance object.
+// See https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#DatabaseInstance
 type CloudSQLInstanceParameters struct {
 	// Region: The geographical region. Can be us-central (FIRST_GEN
 	// instances only), us-central1 (SECOND_GEN instances only), asia-east1
@@ -543,6 +468,82 @@ type OnPremisesConfiguration struct {
 	// HostPort: The host and port of the on-premises instance in host:port
 	// format
 	HostPort string `json:"hostPort"`
+}
+
+// CloudSQLInstanceObservation is used to show the observed state of the Cloud SQL resource on GCP.
+type CloudSQLInstanceObservation struct {
+	// BackendType: FIRST_GEN: First Generation instance. MySQL
+	// only.
+	// SECOND_GEN: Second Generation instance or PostgreSQL
+	// instance.
+	// EXTERNAL: A database server that is not managed by Google.
+	// This property is read-only; use the tier property in the settings
+	// object to determine the database type and Second or First Generation.
+	BackendType string `json:"backendType,omitempty"`
+
+	// CurrentDiskSize: The current disk usage of the instance in bytes.
+	// This property has been deprecated. Users should use the
+	// "cloudsql.googleapis.com/database/disk/bytes_used" metric in Cloud
+	// Monitoring API instead. Please see this announcement for details.
+	CurrentDiskSize int64 `json:"currentDiskSize,omitempty"`
+
+	// ConnectionName: Connection name of the Cloud SQL instance used in
+	// connection strings.
+	ConnectionName string `json:"connectionName,omitempty"`
+
+	// DiskEncryptionStatus: Disk encryption status specific to an instance.
+	// Applies only to Second Generation instances.
+	DiskEncryptionStatus *DiskEncryptionStatus `json:"diskEncryptionStatus,omitempty"`
+
+	// FailoverReplica: The name and status of the failover replica. This
+	// property is applicable only to Second Generation instances.
+	FailoverReplica *DatabaseInstanceFailoverReplicaStatus `json:"failoverReplica,omitempty"`
+
+	// GceZone: The Compute Engine zone that the instance is currently
+	// serving from. This value could be different from the zone that was
+	// specified when the instance was created if the instance has failed
+	// over to its secondary zone.
+	GceZone string `json:"gceZone,omitempty"`
+
+	// IPAddresses: The assigned IP addresses for the instance.
+	IPAddresses []*IPMapping `json:"ipAddresses,omitempty"`
+
+	// IPv6Address: The IPv6 address assigned to the instance. This property
+	// is applicable only to First Generation instances.
+	IPv6Address string `json:"ipv6Address,omitempty"`
+
+	// Project: The project ID of the project containing the Cloud SQL
+	// instance. The Google apps domain is prefixed if applicable.
+	Project string `json:"project,omitempty"`
+
+	// SelfLink: The URI of this resource.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// ServiceAccountEmailAddress: The service account email address
+	// assigned to the instance. This property is applicable only to Second
+	// Generation instances.
+	ServiceAccountEmailAddress string `json:"serviceAccountEmailAddress,omitempty"`
+
+	// State: The current serving state of the Cloud SQL instance. This can
+	// be one of the following.
+	// RUNNABLE: The instance is running, or is ready to run when
+	// accessed.
+	// SUSPENDED: The instance is not available, for example due to problems
+	// with billing.
+	// PENDING_CREATE: The instance is being created.
+	// MAINTENANCE: The instance is down for maintenance.
+	// FAILED: The instance creation failed.
+	// UNKNOWN_STATE: The state of the instance is unknown.
+	State string `json:"state,omitempty"`
+
+	// NOTE(muvaf): This comes from Settings sub-struct, not directly from
+	// DatabaseInstance struct.
+
+	// SettingsVersion: The version of instance settings. This is a required
+	// field for update method to make sure concurrent updates are handled
+	// properly. During update, use the most recent settingsVersion value
+	// for this instance and do not try to update this value.
+	SettingsVersion int64 `json:"settingsVersion,omitempty"`
 }
 
 // IPMapping is database instance IP Mapping.

--- a/config/crd/container.gcp.crossplane.io_gkeclusterclasses.yaml
+++ b/config/crd/container.gcp.crossplane.io_gkeclusterclasses.yaml
@@ -50,7 +50,8 @@ spec:
           properties:
             forProvider:
               description: GKEClusterParameters define the desired state of a Google
-                Kubernetes Engine cluster.
+                Kubernetes Engine cluster. Most of its fields are direct mirror of
+                GCP Cluster object. See https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster
               properties:
                 addonsConfig:
                   description: 'AddonsConfig: Configurations for the various addons

--- a/config/crd/container.gcp.crossplane.io_gkeclusters.yaml
+++ b/config/crd/container.gcp.crossplane.io_gkeclusters.yaml
@@ -138,7 +138,8 @@ spec:
               type: object
             forProvider:
               description: GKEClusterParameters define the desired state of a Google
-                Kubernetes Engine cluster.
+                Kubernetes Engine cluster. Most of its fields are direct mirror of
+                GCP Cluster object. See https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster
               properties:
                 addonsConfig:
                   description: 'AddonsConfig: Configurations for the various addons

--- a/config/crd/database.gcp.crossplane.io_cloudsqlinstanceclasses.yaml
+++ b/config/crd/database.gcp.crossplane.io_cloudsqlinstanceclasses.yaml
@@ -49,7 +49,8 @@ spec:
           properties:
             forProvider:
               description: CloudSQLInstanceParameters define the desired state of
-                a Google CloudSQL instance.
+                a Google CloudSQL instance. Most of its fields are direct mirror of
+                GCP DatabaseInstance object. See https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#DatabaseInstance
               properties:
                 databaseVersion:
                   description: 'DatabaseVersion: The database engine type and version.

--- a/config/crd/database.gcp.crossplane.io_cloudsqlinstances.yaml
+++ b/config/crd/database.gcp.crossplane.io_cloudsqlinstances.yaml
@@ -132,7 +132,8 @@ spec:
               type: object
             forProvider:
               description: CloudSQLInstanceParameters define the desired state of
-                a Google CloudSQL instance.
+                a Google CloudSQL instance. Most of its fields are direct mirror of
+                GCP DatabaseInstance object. See https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#DatabaseInstance
               properties:
                 databaseVersion:
                   description: 'DatabaseVersion: The database engine type and version.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Parameters structs should be the first struct in API types so that they appear on top in docs. Otherwise it's really hard to browse the API reference doc and find how you should construct your object.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [x] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/resources
