### PR TITLE
fix: Update example to use GKE v1.20 with OAuth and Google service account

### DIFF
--- a/examples/gke/gke.yaml
+++ b/examples/gke/gke.yaml
@@ -4,12 +4,9 @@ metadata:
   name: example-cluster
 spec:
   forProvider:
-    initialClusterVersion: "1.18"
+    initialClusterVersion: "1.20"
     location: us-west2
-    masterAuth:
-      # setting this master auth user name enables basic auth so that a client (e.g.,
-      # provider-helm), can connect with the generated kubeconfig from the connection secret
-      username: admin
+    serviceAccount: sa-test
     networkConfig:
       enableIntraNodeVisibility: true
     loggingService: logging.googleapis.com/kubernetes


### PR DESCRIPTION
GKE 1.18 is not supported and GKE 1.20 no longer supports basic master auth https://github.com/crossplane-contrib/provider-helm/issues/72.

Fixes the following issue:

```
'create failed: cannot create GKE cluster: googleapi: Error 400: No valid
      versions with the prefix "1.18" found., badRequest'
```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Create a GKE SA named test-sa with sufficient permissions. Tested with GKE 1.20.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
